### PR TITLE
Adopt and polish formControl demo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
+    id("dev.fritz2.fritz2-gradle") version "0.8"
     kotlin("multiplatform") version "1.4.10"
 }
 
 repositories {
-    mavenLocal()
+    //mavenLocal()
     jcenter()
     maven("https://oss.jfrog.org/artifactory/jfrog-dependencies")
     maven("https://dl.bintray.com/jwstegemann/fritz2")
@@ -27,7 +28,6 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation("dev.fritz2:components:0.9-SNAPSHOT")
-                implementation("dev.fritz2:styling:0.9-SNAPSHOT")
             }
         }
 

--- a/src/commonMain/kotlin/dev/fritz2/kitchensink/formControlModel.kt
+++ b/src/commonMain/kotlin/dev/fritz2/kitchensink/formControlModel.kt
@@ -1,0 +1,121 @@
+package dev.fritz2.kitchensink
+
+import dev.fritz2.components.validation.*
+import dev.fritz2.identification.RootInspector
+import dev.fritz2.identification.inspect
+import dev.fritz2.lenses.Lenses
+
+@Lenses
+data class Account(
+    val username: String,
+    val passphrase: String,
+    val interests: List<String>,
+    val confirmation: Boolean
+)
+
+enum class AccountCreationPhase {
+    Input,
+    Registration
+}
+
+object AccountValidator : ComponentValidator<Account, AccountCreationPhase>() {
+    override fun validate(data: Account, metadata: AccountCreationPhase): List<ComponentValidationMessage> {
+        val inspector = inspect(data)
+        return validateUsername(inspector, metadata) +
+                validatePassphrase(inspector, metadata) +
+                validateInterests(inspector) +
+                validateConfirmation(inspector, metadata)
+    }
+
+    private fun addSuccessMessage(
+        messages: MutableList<ComponentValidationMessage>,
+        phase: AccountCreationPhase,
+        id: String
+    ) {
+        if (phase == AccountCreationPhase.Input && !messages.any { it.isError() }) {
+            messages.add(successMessage(id, ""))
+        }
+    }
+
+    private fun validateUsername(
+        inspector: RootInspector<Account>,
+        phase: AccountCreationPhase
+    ): List<ComponentValidationMessage> {
+        val messages = mutableListOf<ComponentValidationMessage>()
+        val username = inspector.sub(L.Account.username)
+        if (username.data.isBlank() && phase == AccountCreationPhase.Registration) {
+            messages.add(errorMessage(username.id, "Username should not be empty!"))
+        } else if (username.data.isNotBlank()) {
+            if (username.data.contains(':')) {
+                messages.add(errorMessage(username.id, "Username should not contain a colon!"))
+            }
+            if (username.data.length < 3) {
+                messages.add(warningMessage(username.id, "Consider a longer name!"))
+            }
+            addSuccessMessage(messages, phase, username.id)
+        }
+        return messages
+    }
+
+    private fun validatePassphrase(
+        inspector: RootInspector<Account>,
+        phase: AccountCreationPhase
+    ): List<ComponentValidationMessage> {
+        val messages = mutableListOf<ComponentValidationMessage>()
+        val passphrase = inspector.sub(L.Account.passphrase)
+        if (passphrase.data.isBlank() && phase == AccountCreationPhase.Registration) {
+            messages.add(errorMessage(passphrase.id, "Passphrase should not be empty!"))
+        } else if (passphrase.data.isNotBlank()) {
+            if (passphrase.data.length < 16) {
+                messages.add(
+                    warningMessage(passphrase.id, "Consider a passphrase with at least 16 characters")
+                )
+            }
+            if (passphrase.data.toLowerCase() == "fritz2") {
+                messages.add(
+                    warningMessage(passphrase.id, "'fritz2' is a great framework, but a poor passphrase!")
+                )
+            }
+            addSuccessMessage(messages, phase, passphrase.id)
+        }
+        return messages
+    }
+
+    private fun validateInterests(
+        inspector: RootInspector<Account>,
+    ): List<ComponentValidationMessage> {
+        val messages = mutableListOf<ComponentValidationMessage>()
+        val interests = inspector.sub(L.Account.interests)
+        if (interests.data.size > 3) {
+            messages.add(
+                errorMessage(
+                    interests.id,
+                    "You have chosen ${interests.data.size} items, but only 3 items are allowed!"
+                )
+            )
+        }
+        if (interests.data.contains("fritz2")) {
+            messages.add(
+                infoMessage(
+                    interests.id,
+                    "Thank you for choosing fritz2! We appreciate your interest \uD83D\uDE00"
+                )
+            )
+        }
+        return messages
+    }
+
+    private fun validateConfirmation(
+        inspector: RootInspector<Account>,
+        phase: AccountCreationPhase
+    ): List<ComponentValidationMessage> {
+        val messages = mutableListOf<ComponentValidationMessage>()
+        val confirmation = inspector.sub(L.Account.confirmation)
+        if (!confirmation.data && phase == AccountCreationPhase.Registration) {
+            messages.add(errorMessage(confirmation.id, "You must accept license conditions to register!"))
+        } else if (confirmation.data) {
+            addSuccessMessage(messages, phase, confirmation.id)
+        }
+        return messages
+    }
+}

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/checkboxesDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/checkboxesDemo.kt
@@ -35,7 +35,7 @@ fun RenderContext.checkboxesDemo(): Div {
         val usageCheckboxGroupStore = RootStore(listOf("item 2", "item 3"))
         val customCheckboxStore1 = storeOf(false)
         val customCheckboxStore2 = storeOf(true)
-        val customCheckboxStore3 = storeOf(false)
+        val customCheckboxStore3 = storeOf(true)
         val customCheckboxStore4 = storeOf(false)
         val sizesCheckboxStore1 = storeOf(false)
         val sizesCheckboxStore2 = storeOf(true)
@@ -50,7 +50,7 @@ fun RenderContext.checkboxesDemo(): Div {
         componentFrame {
             checkbox {
                 label("A single Checkbox")
-                checked ( usageCheckboxStore.data )
+                checked(usageCheckboxStore.data)
                 events {
                     changes.states() handledBy usageCheckboxStore.update
                 }
@@ -112,19 +112,19 @@ fun RenderContext.checkboxesDemo(): Div {
                 {
                     alignItems { center }
                 }
-            ){
+            ) {
                 items {
                     checkbox {
                         label("small")
                         size { small }
-                        checked ( sizesCheckboxStore1.data )
+                        checked(sizesCheckboxStore1.data)
                         events {
                             changes.states() handledBy sizesCheckboxStore1.update
                         }
                     }
                     checkbox {
                         label("normal")
-                        checked ( sizesCheckboxStore2.data )
+                        checked(sizesCheckboxStore2.data)
                         events {
                             changes.states() handledBy sizesCheckboxStore2.update
                         }
@@ -132,7 +132,7 @@ fun RenderContext.checkboxesDemo(): Div {
                     checkbox {
                         label("large")
                         size { large }
-                        checked ( sizesCheckboxStore3.data )
+                        checked(sizesCheckboxStore3.data)
                         events {
                             changes.states() handledBy sizesCheckboxStore3.update
                         }
@@ -176,7 +176,7 @@ fun RenderContext.checkboxesDemo(): Div {
                         background { color { secondary } }
                     }) {
                         label("Changed unchecked background color")
-                        checked ( customCheckboxStore1.data )
+                        checked(customCheckboxStore1.data)
                         events {
                             changes.states() handledBy customCheckboxStore1.update
                         }
@@ -185,9 +185,9 @@ fun RenderContext.checkboxesDemo(): Div {
                     checkbox {
                         label("Changed checked border color")
                         checkedStyle {
-                            { border { color { secondary }}}
+                            border { color { secondary } }
                         }
-                        checked ( customCheckboxStore2.data )
+                        checked(customCheckboxStore2.data)
                         events {
                             changes.states() handledBy customCheckboxStore2.update
                         }
@@ -195,8 +195,8 @@ fun RenderContext.checkboxesDemo(): Div {
 
                     checkbox {
                         label("Changed checkmark to fritz2 icon")
-                        icon { Theme().icons.fritz2 }
-                        checked ( customCheckboxStore3.data )
+                        icon { fritz2 }
+                        checked(customCheckboxStore3.data)
                         events {
                             changes.states() handledBy customCheckboxStore3.update
                         }
@@ -204,8 +204,8 @@ fun RenderContext.checkboxesDemo(): Div {
 
                     checkbox {
                         label("Custom label style: larger margin")
-                        labelStyle { { margins { left { larger } } } }
-                        checked ( customCheckboxStore4.data )
+                        labelStyle { margins { left { larger } } }
+                        checked(customCheckboxStore4.data)
                         events {
                             changes.states() handledBy customCheckboxStore4.update
                         }
@@ -225,19 +225,21 @@ fun RenderContext.checkboxesDemo(): Div {
                     checkbox {
                         label("Changed checked border color")
                         checkedStyle {
-                            { border { color { secondary }}}
+                            border { color { secondary } }
                         }
                     }
 
                     checkbox {
                         label("Changed checkmark to fritz2 icon")
-                        checked ( flowOf(true) )
-                        icon { Theme().icons.fritz2 }
+                        checked(true)
+                        icon { fritz2 }
                     }
 
                     checkbox {
                         label("Custom label style: larger margin")
-                        labelStyle { { margins { left { larger } } } }
+                        labelStyle { 
+                            margins { left { larger } } 
+                        }
                     }
                     """
             )
@@ -250,16 +252,16 @@ fun RenderContext.checkboxesDemo(): Div {
             stackUp {
                 items {
                     checkbox {
-                        checked ( usageCheckboxStore.data )
+                        checked(usageCheckboxStore.data)
                         label("A disabled checkbox or checkboxGroup can not be selected.")
-                        disabled ( flowOf(true) )
+                        disabled(flowOf(true))
                         events {
                             changes.states() handledBy usageCheckboxStore.update
                         }
                     }
                     checkboxGroup(store = usageCheckboxGroupStore, items = demoItems) {
                         direction { column }
-                        disabled ( flowOf(true) )
+                        disabled(flowOf(true))
                     }
                 }
 
@@ -270,12 +272,12 @@ fun RenderContext.checkboxesDemo(): Div {
                 """
                     checkbox {
                         label("A disabled Checkbox or CheckboxGroup can not be selected.")
-                        disabled ( flowOf(true) )
+                        disabled(true)
                     }
                     
                     checkboxGroup(store = selectedItemsStore, items = allItems) {
                         direction { column }
-                        disabled ( flowOf(true) )
+                        disabled(true)
                     }
                     """
             )

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/radioDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/radioDemo.kt
@@ -94,14 +94,14 @@ fun RenderContext.radiosDemo(): Div {
                     radio {
                         label("small")
                         size { small }
-                        selected (smallStore.data)
+                        selected(smallStore.data)
                         events {
                             changes.states() handledBy smallStore.update
                         }
                     }
                     radio {
                         label("normal")
-                        selected (normalStore.data)
+                        selected(normalStore.data)
                         events {
                             changes.states() handledBy normalStore.update
                         }
@@ -109,7 +109,7 @@ fun RenderContext.radiosDemo(): Div {
                     radio {
                         label("large")
                         size { large }
-                        selected (largeStore.data)
+                        selected(largeStore.data)
                         events {
                             changes.states() handledBy largeStore.update
                         }
@@ -146,7 +146,7 @@ fun RenderContext.radiosDemo(): Div {
             +" parameter, you can display the radios in a row or as a column."
         }
         componentFrame {
-            radioGroup(store = usageRadioGroupStore, items = demoItems ) {
+            radioGroup(store = usageRadioGroupStore, items = demoItems) {
                 direction { row }
             }
         }
@@ -182,19 +182,23 @@ fun RenderContext.radiosDemo(): Div {
                         border { color { secondary } }
                     }) {
                         label("Custom unselected style")
-                        selected (flowOf(false))
+                        selected(false)
                     }
 
                     radio {
                         label("Custom selected style")
-                        selected(flowOf(true))
-                        selectedStyle { { background { color { secondary } } } }
+                        selected(true)
+                        selectedStyle {
+                            background { color { secondary } }
+                        }
                     }
 
                     radio {
                         label("Custom label style: margin")
-                        selected (usageRadioStore.data)
-                        labelStyle { { margins { left { larger } } } }
+                        selected(usageRadioStore.data)
+                        labelStyle {
+                            margins { left { larger } }
+                        }
                         events {
                             changes.states() handledBy usageRadioStore.update
                         }
@@ -213,31 +217,35 @@ fun RenderContext.radiosDemo(): Div {
 
                     radio {
                         label("Custom selected style")
-                        selected (flowOf(true))
-                        selectedStyle { { background { color { secondary } } } }
+                        selected(true)
+                        selectedStyle { 
+                            background { color { secondary } }  
+                        }
                     }
 
                     radio {
                         label("Custom label style: margin")
-                        labelStyle { { margins { left { larger } } } }
+                        labelStyle { 
+                            margins { left { larger } } 
+                        }     
                     }
                     """
             )
         }
 
-       showcaseSection("Disabled Radios")
+        showcaseSection("Disabled Radios")
         componentFrame {
             stackUp {
                 items {
                     radio {
                         label("A disabled Radio or RadioGroup can not be selected.")
-                        disabled(flowOf(true))
-                        selected (usageRadioStore.data)
+                        disabled(true)
+                        selected(usageRadioStore.data)
                     }
 
                     radioGroup(store = usageRadioGroupStore, items = demoItems) {
                         direction { column }
-                        disabled(flowOf(true))
+                        disabled(true)
                     }
                 }
 
@@ -248,12 +256,12 @@ fun RenderContext.radiosDemo(): Div {
                 """
                     radio {
                         label("A disabled Radio or RadioGroup can not be selected.")
-                        disabled(flowOf(true))
+                        disabled(true)
                     }
                     
                     radioGroup(store = usageRadioGroupStore, items = demoItems) {
                         direction { column }
-                        disabled(flowOf(true))
+                        disabled(true)
                     }
                     """
             )

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/selectDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/selectDemo.kt
@@ -86,10 +86,10 @@ fun RenderContext.selectDemo(): Div {
                         size { small }
 
                     }
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("normal (default)")
                     }
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("large")
                         size { large }
                     }
@@ -128,10 +128,10 @@ fun RenderContext.selectDemo(): Div {
         componentFrame {
             stackUp {
                 items {
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("outline (default)")
                     }
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("filled")
                         variant { filled }
                     }
@@ -163,14 +163,14 @@ fun RenderContext.selectDemo(): Div {
         componentFrame {
             stackUp {
                 items {
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("Large with circleAdd-Icon")
-                        icon { Theme().icons.circleAdd }
+                        icon { circleAdd }
                         size { large }
                     }
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("Small with arrowDown-Icon")
-                        icon { Theme().icons.arrowDown }
+                        icon { arrowDown }
                         size { small }
                     }
                 }
@@ -181,12 +181,12 @@ fun RenderContext.selectDemo(): Div {
                 """
             selectField(items = myList) {
                 placeholder("Large with circleAdd-Icon")
-                icon { Theme().icons.circleAdd }
+                icon { circleAdd }
                 size { large }
             }
             select(items = myList) {
                 placeholder("Small with arrowDown-Icon")
-                icon { Theme().icons.arrowDown }
+                icon { arrowDown }
                 size { small }
             }
                 """.trimIndent()
@@ -200,7 +200,7 @@ fun RenderContext.selectDemo(): Div {
         paragraph {
             +"As mentioned in the usage section, you can pass items of any type to the select. You can specify how the label is generated (if "
             +" you don't specify anything, the "
-            c( "toString()")
+            c("toString()")
             +" method of your class will be used). The following example renders a list of persons with name and id."
 
 
@@ -234,7 +234,7 @@ fun RenderContext.selectDemo(): Div {
                  val persons = listOf(Person("John Doe", 16), Person("Jane Doe", 42))
                  val store = storeOf(persons[0])
                  selectField(store = store, items = persons) {
-                        label { it.name } // instead of person.toString(), use name member as label
+                     label { it.name } // instead of person.toString(), use name member as label
                  }
                 """.trimIndent()
             )
@@ -250,7 +250,7 @@ fun RenderContext.selectDemo(): Div {
         componentFrame {
             lineUp {
                 items {
-                    selectField<Any>(items = emptyList())  {
+                    selectField<Any>(items = emptyList()) {
                         placeholder("disabled selectField")
                         disabled(true)
                     }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/switchDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/switchDemo.kt
@@ -33,7 +33,7 @@ fun RenderContext.switchDemo(): Div {
         componentFrame {
             switch {
                 label("Simple Switch")
-                checked ( checkedStore1.data )
+                checked(checkedStore1.data)
                 events {
                     changes.states() handledBy checkedStore1.update
                 }
@@ -45,7 +45,7 @@ fun RenderContext.switchDemo(): Div {
                 """
                 switch {
                     label("Simple Switch")
-                    checked ( checkedStore.data )
+                    checked(checkedStore.data)
                     events {
                         changes.states() handledBy checkedStore.update
                     }
@@ -70,7 +70,7 @@ fun RenderContext.switchDemo(): Div {
             switch() {
                 label("Small")
                 size { small }
-                checked ( checkedStore4.data )
+                checked(checkedStore4.data)
                 events {
                     changes.states() handledBy checkedStore4.update
                 }
@@ -79,7 +79,7 @@ fun RenderContext.switchDemo(): Div {
         componentFrame {
             switch() {
                 label("Normal (default)")
-                checked ( checkedStore5.data )
+                checked(checkedStore5.data)
                 events {
                     changes.states() handledBy checkedStore5.update
                 }
@@ -89,7 +89,7 @@ fun RenderContext.switchDemo(): Div {
             switch() {
                 label("Large")
                 size { large }
-                checked ( checkedStore6.data )
+                checked(checkedStore6.data)
                 events {
                     changes.states() handledBy checkedStore6.update
                 }
@@ -124,9 +124,9 @@ fun RenderContext.switchDemo(): Div {
                 }
             }) {
                 label("Custom background colors")
-                checked ( checkedStore2.data )
+                checked(checkedStore2.data)
                 checkedStyle {
-                    { background { color { secondary } } }
+                    background { color { secondary } }
                 }
                 events {
                     changes.states() handledBy checkedStore2.update
@@ -136,13 +136,11 @@ fun RenderContext.switchDemo(): Div {
         componentFrame {
             switch {
                 label("Custom dot")
-                checked ( checkedStore3.data )
+                checked(checkedStore3.data)
                 dotStyle {
-                    {
-                        size { "0.8rem" }
-                        radius { "3px" }
-                        background { color { dark } }
-                    }
+                    size { "0.8rem" }
+                    radius { "3px" }
+                    background { color { dark } }
                 }
                 events {
                     changes.states() handledBy checkedStore3.update
@@ -161,7 +159,7 @@ fun RenderContext.switchDemo(): Div {
                     label("Custom background colors")
                     // use component function to change checked style
                     checkedStyle {
-                        { background { color { primary } } }
+                        background { color { primary } }
                     }
                 }    
 
@@ -169,16 +167,13 @@ fun RenderContext.switchDemo(): Div {
                     label("Custom dot")
                     // use component function to change dot style
                     dotStyle {
-                        {
-                            size { "0.8rem" }
-                            radius { "3px" }
-                            background { color { dark } }
-                        }
+                        size { "0.8rem" }
+                        radius { "3px" }
+                        background { color { dark } }
                     }
                 }
                 """
             )
         }
-
     }
 }


### PR DESCRIPTION
- add complex form example for showing integration of model, store,
  validation and formControls
- updated customization example with detailed explanations
- removed redundant examples and susbitute theme by relevant API usage
  examples like styling and custom validation messages
- rework checkboxes and radio demos for adopting normalization of
  their styling properties (obsolete double lambda expression was removed)