### PR TITLE
Adapt demo pages to CloseButton API

### DIFF
--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/modalDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/modalDemo.kt
@@ -233,26 +233,22 @@ fun RenderContext.modalDemo(): Div {
 
         showcaseSection("Customized Close Buttons")
         paragraph {
-            +"You can customize the close button calling the modal's function "
-            c("closeButton")
-            +" with your own styling parameters:"
+            +"You can customize the close button by overriding the default rendering via the "
+            c("closeButtonRendering")
+            +" property:"
         }
         componentFrame {
             lineUp {
                 items {
                     clickButton {
-                        text("Styled Close Button")
+                        text("Customized Close Button")
                     } handledBy modal {
                         closeButtonRendering {
                             clickButton({
                                 background { color { danger } }
                                 color { base }
-                                position {
-                                    absolute {
-                                        top { normal }
-                                    }
-                                }
-                                css("transform: rotate(20deg) translateX(-.5rem)")
+                                position { absolute { top { normal } } }
+                                css("transform: rotate(-20deg) translateX(-.5rem)")
                             }) {
                                 size { small }
                                 text("Nope")
@@ -268,21 +264,19 @@ fun RenderContext.modalDemo(): Div {
             source(
                 """
                 clickButton {
-                    text("Styled Close Button")
+                    text("Customized  Close Button")
                 } handledBy modal {
-                    closeButton({
-                        background { color { danger } }
-                        color { base }
-                        position {
-                            absolute {
-                                top { normal }
-                            }
+                    closeButtonRendering {
+                        clickButton({
+                            background { color { danger } }
+                            color { base }
+                            position { absolute { top { normal } } }
+                            css("transform: rotate(-20deg) translateX(-.5rem)")
+                        }) {
+                            size { small }
+                            text("Nope")
+                            iconPlacement { right }
                         }
-                        css("transform: rotate(20deg) translateX(-.5rem)")
-                    }) {
-                        size { small }
-                        text("Nope")
-                        iconPlacement{right}
                     }
                 }
             """.trimIndent()

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/popoverDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/popoverDemo.kt
@@ -205,18 +205,21 @@ fun RenderContext.popoverDemo(): Div {
 
 
 
-        showcaseSection("Close button")
+        showcaseSection("Close Button")
 
 
         paragraph {
 
             +"The popover has a default close button which you can hide using "
             c("hasCloseButton(false)")
-            +" - this way, the popover can only be closed by clicking the toggle again. Alternatively, you can create"
-            +" your own close button with the "
-            c("closeButton {}")
-            +" function offered by the component's context."
-
+            +" - this way, the popover can only be closed by clicking the toggle again. Alternatively, you can change"
+            +" the icon of the close button with the "
+            c("closeButtonIcon")
+            +" and the styling via the "
+            c("closeButtonStyling")
+            +" properties offered by the component's context. You can even override the whole rendering with the "
+            c("closeButtonRendering")
+            +" property."
         }
         componentFrame {
             lineUp {
@@ -237,18 +240,11 @@ fun RenderContext.popoverDemo(): Div {
                         toggle {
                             icon({ size { huge } }) { fromTheme { eye } }
                         }
-                        closeButtonRendering {
-                            clickButton({
-                                closeButtonStyle.value()
-                                size { normal }
-                                width { auto }
-                            }) {
-                                icon { fromTheme { eyeOff } }
-                            }
-                        }
+                        closeButtonIcon { eyeOff }
+                        closeButtonStyle { color { danger } }
                         content {
                             div {
-                                +"A custom button replaces the default button."
+                                +"A custom icon for the button."
                             }
                         }
                     }
@@ -275,12 +271,11 @@ fun RenderContext.popoverDemo(): Div {
                     toggle {
                         icon({ size { huge } }) { fromTheme { eye } }
                     }
-                    closeButton({ size { normal } }) {
-                        icon { fromTheme { eyeOff } }
-                    }
+                    closeButtonIcon { eyeOff }
+                    closeButtonStyle { color { danger } }                    
                     content {
                         div {
-                            +"A custom button replaces the default button."
+                            +"A custom icon for the button."
                         }
                     }
                 }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/toastDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/toastDemo.kt
@@ -380,20 +380,25 @@ fun RenderContext.toastDemo(): Div {
             )
         }
 
-        showcaseSubSection("Close-Button")
+        showcaseSubSection("Close Button")
         paragraph {
-            +"The close button's style can optionally be overridden via the "
+            +"The close button can optionally be customized via the"
             c("closeButtonStyle")
-            +" property."
+            +", "
+            c("closeButtonIcon")
+            +" or ultimately by the "
+            c("closeButtonRendering")
+            +" properties."
         }
         componentFrame {
             clickButton {
                 text("Show")
             } handledBy toast {
                 closeButtonStyle {
-                    background { color { lightGray } }
-                    color { darkGray }
+                    margins { right { small } }
+                    background { color { warning } }
                 }
+                closeButtonIcon { fritz2 }
                 content {
                     basicStyledToastContent()
                 }
@@ -404,9 +409,10 @@ fun RenderContext.toastDemo(): Div {
                 """
                     showToast {
                         closeButtonStyle {
-                            background { color { lightGray } }
-                            color { darkGray }
+                            margins { right { small } }
+                            background { color { warning } }
                         }
+                        closeButtonIcon { fritz2 }
                         content {
                             basicStyledToastContent()
                         }
@@ -464,7 +470,7 @@ fun RenderContext.toastDemo(): Div {
             +"Toasts can manually be dismissed by clicking on it's close button which is part of every toast"
         }
 
-        showcaseSubSection("Close-Button")
+        showcaseSubSection("Close Button")
         paragraph {
             +"Toasts can manually be dismissed by clicking on the close buttons which are part of every toast"
             +" by default. The close button can be enabled/disabled via the "


### PR DESCRIPTION
- correct descriptions and example source code
- correct headings to unified name for ``Close Button`` sections