### PR TITLE
Replace usages of `box`

### DIFF
--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/app.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/app.kt
@@ -98,7 +98,7 @@ fun main() {
     val menuBackgroundColor = Theme().colors.neutral
 
     render(themes.first()) {
-        box({
+        div({
             height { "100%" }
             width { "100%" }
             position { relative {} }
@@ -319,7 +319,7 @@ fun main() {
 
                         }
                     }
-                    box({
+                    div({
                         paddings(md = {
                             left { large }
                             top { small }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/base/base.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/base/base.kt
@@ -1,6 +1,5 @@
 package dev.fritz2.kitchensink.base
 
-import dev.fritz2.components.box
 import dev.fritz2.dom.html.A
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.P
@@ -70,7 +69,7 @@ fun RenderContext.contentFrame(
 }, styling, baseClass, id, prefix, content)
 
 fun RenderContext.coloredBox(colorScheme: ColorScheme, content: P.() -> Unit): Div {
-    return box({
+    return div({
         margins {
             top { larger }
             bottom { larger }
@@ -101,7 +100,7 @@ fun RenderContext.coloredBox(colorScheme: ColorScheme, content: P.() -> Unit): D
 }
 
 fun RenderContext.componentFrame(padding: Boolean = true, content: Div.() -> Unit): Div {
-    return box({
+    return div({
         width { "100%" }
         margins {
             top { "1.25rem" }
@@ -118,7 +117,7 @@ fun RenderContext.componentFrame(padding: Boolean = true, content: Div.() -> Uni
 fun RenderContext.storeContentBox(
     label: String,
     content: RenderContext.() -> Unit = {}
-): Div = box({
+): Div = div({
         background {
             color { gray200 }
         }
@@ -164,7 +163,7 @@ fun RenderContext.internalLink(text: String, page: String): A {
 }
 
 fun RenderContext.navAnchor(linkText: String, href: String): Div {
-    return box({
+    return div({
         radius { small }
         border {
             width { none }
@@ -196,7 +195,7 @@ fun RenderContext.navAnchor(linkText: String, href: String): Div {
 }
 
 fun RenderContext.menuHeader(text: String): Div {
-    return box({
+    return div({
         width { "100%" }
     }) {
         p({
@@ -273,7 +272,7 @@ fun RenderContext.c(text: String) {
 
 fun RenderContext.teaserText(
     content: Div.() -> Unit = {}
-): Div = box({
+): Div = div({
     fontSize { small }
     textTransform { capitalize }
     color { primary.main }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/base/highlight.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/base/highlight.kt
@@ -1,9 +1,9 @@
 package dev.fritz2.kitchensink.base
 
-import dev.fritz2.components.box
 import dev.fritz2.components.stackUp
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.kitchensink.highlightBackgroundColor
+import dev.fritz2.styling.div
 import kotlinx.browser.window
 
 /**
@@ -43,7 +43,7 @@ fun RenderContext.highlight(
         }
     }){
         items {
-            box({
+            div({
                 background { color { highlightBackgroundColor } }
                 radius { small }
                 width { full }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/base/playground.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/base/playground.kt
@@ -1,7 +1,7 @@
 package dev.fritz2.kitchensink.base
 
-import dev.fritz2.components.box
 import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.styling.div
 import dev.fritz2.styling.staticStyle
 import kotlinx.browser.window
 
@@ -77,7 +77,7 @@ fun RenderContext.playground(
     val component = PlaygroundComponent().apply(build)
 
 
-    box({
+    div({
         margins { top { large } }
         display { flex }
         background { color { backgroundColor } }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/alertDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/alertDemo.kt
@@ -1,11 +1,11 @@
 package dev.fritz2.kitchensink.demos
 
 import dev.fritz2.components.alert
-import dev.fritz2.components.box
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.kitchensink.base.*
 import dev.fritz2.kitchensink.toasts_
+import dev.fritz2.styling.div
 import dev.fritz2.styling.span
 import dev.fritz2.styling.theme.AlertSeverity
 import dev.fritz2.styling.theme.ColorScheme
@@ -259,7 +259,7 @@ fun RenderContext.alertDemo(): Div {
             }) {
                 title {
                     // Title that takes up the whole line
-                    box({
+                    div({
                         fontWeight { bold }
                     }) {
                         +"Custom title"

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/alertDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/alertDemo.kt
@@ -286,7 +286,7 @@ fun RenderContext.alertDemo(): Div {
                     alert {
                         title {
                             // Title that takes up the whole line
-                            box({
+                            div({
                                 fontWeight { bold }
                             }) {
                                 +"Custom title"

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/colorDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/colorDemo.kt
@@ -1,11 +1,15 @@
 package dev.fritz2.kitchensink.demos
 
 import dev.fritz2.binding.storeOf
-import dev.fritz2.components.*
+import dev.fritz2.components.flexBox
+import dev.fritz2.components.gridBox
+import dev.fritz2.components.lineUp
+import dev.fritz2.components.tooltip
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.kitchensink.base.*
 import dev.fritz2.kitchensink.theme_
+import dev.fritz2.styling.div
 import dev.fritz2.styling.p
 import dev.fritz2.styling.params.*
 import dev.fritz2.styling.theme.ColorScheme
@@ -77,7 +81,7 @@ fun renderColorScheme(context: RenderContext, name: String, colorScheme: ColorSc
                 }
                 radii { top { radiiSize() } }
             }) {
-                box({
+                div({
                     fontSize { large }
                 }) { +name }
                 mouseenters.map { true } handledBy hovered.update
@@ -143,7 +147,7 @@ fun RenderContext.createColorBar(
         }
     }) {
         items {
-            box({
+            div({
                 width { "100%" }
                 background {
                     color { color }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/dropdownDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/dropdownDemo.kt
@@ -216,7 +216,7 @@ fun RenderContext.dropdownDemo(): Div {
                 }
             }
 
-            box({
+            div({
                 margins { top { normal } }
             }) {
                 placementAlignmentFlow.render {

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/flexBoxDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/flexBoxDemo.kt
@@ -46,7 +46,7 @@ fun RenderContext.flexBoxDemo(): Div {
         showcaseHeader("Flexbox")
         paragraph {
             +"The flex layout enables a container to alter its items' width,"
-            +" height, and order to best fill the available space. The container is basically a box which has the css"
+            +" height, and order to best fill the available space. The container is basically a div that has the css"
             +" property "
             c("display: flex")
             +" attached."
@@ -76,7 +76,7 @@ fun RenderContext.flexBoxDemo(): Div {
                     width { full }
                 }) {
                    
-                    box({
+                    div({
                         background { color { primary.main } }
                         color { neutral }
                         width (sm = { "50px" }, md = { "110px" }, lg = { "150px" })
@@ -91,8 +91,8 @@ fun RenderContext.flexBoxDemo(): Div {
                     }
                     
                     // styling omitted
-                    box { +"Box 2" }
-                    box { +"Box 3" }
+                    div { +"Box 2" }
+                    div { +"Box 3" }
                 }
                 """
             )
@@ -132,9 +132,9 @@ fun RenderContext.flexBoxDemo(): Div {
                 flexBox({
                     direction { row }
                 }) {
-                    box { +"Box 1"}
-                    box { +"Box 2"}
-                    box { +"Box 3"}
+                    div { +"Box 1"}
+                    div { +"Box 2"}
+                    div { +"Box 3"}
                 }
             """
             )
@@ -180,9 +180,9 @@ fun RenderContext.flexBoxDemo(): Div {
                 flexBox({
                     justifyContent { flexStart }
                 }) {
-                    box { +"Box 1"}
-                    box { +"Box 2"}
-                    box { +"Box 3"}
+                    div { +"Box 1"}
+                    div { +"Box 2"}
+                    div { +"Box 3"}
                 }
                 """
             )
@@ -224,11 +224,11 @@ fun RenderContext.flexBoxDemo(): Div {
                 flexBox({
                     wrap { noWrap }
                 }) {
-                    box { +"Box 1"}
-                    box { +"Box 2"}
-                    box { +"Box 3"}
-                    box { +"Box 4"}
-                    box { +"Box 5"}
+                    div { +"Box 1"}
+                    div { +"Box 2"}
+                    div { +"Box 3"}
+                    div { +"Box 4"}
+                    div { +"Box 5"}
                 }                    
                 """
             )

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/gridBoxDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/gridBoxDemo.kt
@@ -1,12 +1,12 @@
 package dev.fritz2.kitchensink.demos
 
 import dev.fritz2.binding.storeOf
-import dev.fritz2.components.box
 import dev.fritz2.components.gridBox
 import dev.fritz2.components.pushButton
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.kitchensink.base.*
+import dev.fritz2.styling.div
 import dev.fritz2.styling.p
 import dev.fritz2.styling.params.AreaName
 import dev.fritz2.styling.params.end
@@ -134,7 +134,7 @@ fun RenderContext.gridBoxDemo(): Div {
                 )
                 gap { large }
             }) {
-                box({
+                div({
                     grid { area { grid.HEADER } }
                     background {
                         color { gray300 }
@@ -145,7 +145,7 @@ fun RenderContext.gridBoxDemo(): Div {
                         padding { "1rem" }
                     }) { +"Header" }
                 }
-                box({
+                div({
                     grid { area { grid.SIDEBAR } }
                     background { color { primary.main } }
                     color { gray300 }
@@ -155,7 +155,7 @@ fun RenderContext.gridBoxDemo(): Div {
                         padding { "1rem" }
                     }) { +"Sidebar" }
                 }
-                box({
+                div({
                     paddings { all { "0.2rem" } }
                     grid(sm = { area { grid.CONTENT } })
                     background(
@@ -182,7 +182,7 @@ fun RenderContext.gridBoxDemo(): Div {
                         padding { "1rem" }
                     }){ +"Content" }
                 }
-                box({
+                div({
                     grid { area { grid.FOOTER } }
                     background { color { gray300 } }
                     paddings { all { "0.2rem" } }
@@ -193,7 +193,7 @@ fun RenderContext.gridBoxDemo(): Div {
                 }
                 toggle.data.render { show ->
                     if (show) {
-                        box({
+                        div({
                             margin { none }
                             paddings { all { "0.2rem" } }
                             grid(

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/gridBoxDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/gridBoxDemo.kt
@@ -299,13 +299,13 @@ fun RenderContext.gridBoxDemo(): Div {
                 gridBox({
                     // omitted, same as above
                 }) {
-                    box({
+                    div({
                         grid { area { grid.HEADER } } // refer to cell type 
                     }) {
                         // your content
                     }
                     // next type
-                    box({
+                    div({
                         grid { area { grid.CONTENT } }  
                     }) {
                         // your content
@@ -329,7 +329,7 @@ fun RenderContext.gridBoxDemo(): Div {
                     // as above
                 }) {
                     // define the drawer
-                    box({
+                    div({
                         grid(
                             sm = { // structure for small displays
                                 row {

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/stackDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/stackDemo.kt
@@ -1,6 +1,5 @@
 package dev.fritz2.kitchensink.demos
 
-import dev.fritz2.components.box
 import dev.fritz2.components.lineUp
 import dev.fritz2.components.stackUp
 import dev.fritz2.dom.html.Div
@@ -8,6 +7,7 @@ import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.kitchensink.base.*
 import dev.fritz2.kitchensink.flexbox_
 import dev.fritz2.kitchensink.gridbox_
+import dev.fritz2.styling.div
 import dev.fritz2.styling.params.ColorProperty
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +17,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 fun RenderContext.stackDemo(): Div {
 
     val item: RenderContext.(String, String) -> Unit = { color, text ->
-        box({
+        div({
             display { flex }
             justifyContent { center }
             alignItems { center }
@@ -204,7 +204,7 @@ fun RenderContext.stackDemo(): Div {
         }
         componentFrame {
             val sizedBox: RenderContext.(Int, Int, ColorProperty) -> Unit = { w, h, color ->
-                box({
+                div({
                     background { color { color } }
                     width { "${w}px" }
                     height { "${h}px" }

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/toastDemo.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/toastDemo.kt
@@ -50,6 +50,12 @@ fun RenderContext.toastDemo(): Div {
             c("info")
             +" color defined in the theme."
         }
+        coloredBox(Theme().colors.info) {
+            +"Please note: The close-button is rendered above the toast's content. You might need to "
+            +"add some padding to your content in order for it to not be overlapped by the close-button. "
+            br { }
+            +"If you create an alert-toast via the respective functions this is done automatically."
+        }
         componentFrame {
             lineUp {
                 items {
@@ -57,12 +63,7 @@ fun RenderContext.toastDemo(): Div {
                         text("Show")
                     } handledBy toast {
                         content {
-                            p({
-                                margin { small }
-                                color { info.mainContrast }
-                            }) {
-                                +"This is a basic toast."
-                            }
+                            basicStyledToastContent("This is a basic toast.")
                         }
                     }
                 }
@@ -77,7 +78,11 @@ fun RenderContext.toastDemo(): Div {
                     } handledBy toast {
                         content {
                             p({
-                                margin { small }
+                                margins {
+                                    vertical { small }
+                                    left { small }
+                                    right { "80px" }
+                                }
                                 color { info.mainContrast }
                             }) {
                                 +"This is a basic toast."
@@ -453,12 +458,6 @@ fun RenderContext.toastDemo(): Div {
             +" or ultimately by the "
             c("closeButtonRendering")
             +" properties."
-        }
-        coloredBox(Theme().colors.info) {
-            +"Please note: The close-button is rendered above the toast's content so you might need to "
-            +"add some padding to your content so it is not overlapped by the close-button. "
-            br { }
-            +"If you create an alert-toast via the respective functions this is done automatically."
         }
         componentFrame {
             clickButton {

--- a/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/welcome.kt
+++ b/src/jsMain/kotlin/dev.fritz2.kitchensink/demos/welcome.kt
@@ -1,6 +1,5 @@
 package dev.fritz2.kitchensink.demos
 
-import dev.fritz2.components.box
 import dev.fritz2.components.icon
 import dev.fritz2.components.lineUp
 import dev.fritz2.components.stackUp
@@ -35,7 +34,7 @@ fun RenderContext.welcome(): Div {
                     color { primary.main }
                     css("drop-shadow(0 0 0.5rem gray);")
                 }) { fromTheme { fritz2 } }
-                box {
+                div {
                     h1({
                         fontSize(
                             sm = { "1.5rem" },


### PR DESCRIPTION
This PR replaces all occurances of `box`with `div` in order to adapt PR [#483](https://github.com/jwstegemann/fritz2/pull/483) (fritz2).